### PR TITLE
Externalized the MATERIAL_LIST into a settings key

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "randomThemeSwitcher.lastSwitchDay": 2
 }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ A simple extension that chooses and applies a *random* theme.
 
 - `randomThemeSwitcher.themeList`: a list of string with labels of themes.
 
+- `oneMoreTimeThemeList`: a list of themes that will be kept one more time before being changed when randomized
+  - default the material theme suite
+  - set to [ ] in order to disable this behaviour
+
 > __PROTIP:__ For easy setup use the command `Random Theme: Copy all installed themes in settings`
 
 example:
@@ -61,6 +65,11 @@ example:
 - [x] Add key chord for changing theme.
 
 ## Release Notes
+
+## 0.2.1
+
+- Externalized the MATERIAL_LIST into a more customizable `oneMoreTimeThemeList`
+  - With that users can pick up their fauvorites theme and have them one more time (instead of being changed immediately) 
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ example:
 ## 0.2.1
 
 - Externalized the MATERIAL_LIST into a more customizable `oneMoreTimeThemeList`
-  - With that users can pick up their fauvorites theme and have them one more time (instead of being changed immediately) 
+  - With that users can pick up their favorites theme and have them one more time (instead of being changed immediately) 
 
 ## 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ A simple extension that chooses and applies a *random* theme.
 
 - `randomThemeSwitcher.themeList`: a list of string with labels of themes.
 
-- `oneMoreTimeThemeList`: a list of themes that will be kept one more time before being changed when randomized
-  - default the material theme suite
-  - set to [ ] in order to disable this behaviour
+- `preventReloadThemeList`: some themes, after they are applied, reload the instance. If are present in this list the extension will not set a new random theme after they are applied
+  - default to the material theme suite
 
 > __PROTIP:__ For easy setup use the command `Random Theme: Copy all installed themes in settings`
 
@@ -68,7 +67,7 @@ example:
 
 ## 0.2.1
 
-- Externalized the MATERIAL_LIST into a more customizable `oneMoreTimeThemeList`
+- Externalized the MATERIAL_LIST into a more customizable `preventReloadThemeList`
   - With that users can pick up their favorites theme and have them one more time (instead of being changed immediately) 
 
 ## 0.2.0

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "random-theme-switcher",
   "displayName": "Random Theme Switcher",
   "description": "A simple extension that randomly choose a theme",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publisher": "zanza00",
   "icon": "icon/rts.png",
   "author": {
@@ -65,11 +65,13 @@
           "maximum": 1440
         },
         "randomThemeSwitcher.themeList": {
+          "title": "theme list",
           "default": [],
           "description": "List of themes from which a random one is selected, to populate use the command 'copy installed themes'",
           "type": "array"
         },
         "randomThemeSwitcher.switchMode": {
+          "title": "switch mode",
           "type": "string",
           "enum": [
             "manual",
@@ -89,8 +91,26 @@
           "default": true
         },
         "randomThemeSwitcher.lastSwitchDay": {
+          "title": "last switch day",
           "type": "number",
           "description": "Last switch day (used in the switchMode daily)"
+        },
+        "randomThemeSwitcher.oneMoreTimeThemeList": {
+          "title": "one more time theme list",
+          "type": "array",
+          "description": "If a theme is listed here it will stay active one more time before it will be changed",
+          "default": [
+            "Material Theme",
+            "Material Theme High Contrast",
+            "Material Theme Darker",
+            "Material Theme Darker High Contrast",
+            "Material Theme Palenight",
+            "Material Theme Palenight High Contrast",
+            "Material Theme Ocean",
+            "Material Theme Ocean High Contrast",
+            "Material Theme Lighter",
+            "Material Theme Lighter High Contrast"
+          ]
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   ],
   "main": "./dist/extension",
   "contributes": {
-    "commands": [{
+    "commands": [
+      {
         "command": "randomThemeSwitcher.switchTheme",
         "title": "Random Theme: Switch to a Random Theme"
       },
@@ -49,11 +50,13 @@
         "title": "Random Theme: Remove current theme from settings"
       }
     ],
-    "keybindings": [{
-      "command": "randomThemeSwitcher.switchTheme",
-      "key": "ctrl+k ctrl+shift+t",
-      "mac": "cmd+k cmd+shift+t"
-    }],
+    "keybindings": [
+      {
+        "command": "randomThemeSwitcher.switchTheme",
+        "key": "ctrl+k ctrl+shift+t",
+        "mac": "cmd+k cmd+shift+t"
+      }
+    ],
     "configuration": {
       "title": "Random Theme Switcher configuration list",
       "properties": {
@@ -96,10 +99,10 @@
           "description": "Last switch day (used in the switchMode daily)",
           "scope": "application"
         },
-        "randomThemeSwitcher.oneMoreTimeThemeList": {
+        "randomThemeSwitcher.preventReloadThemeList": {
           "title": "one more time theme list",
           "type": "array",
-          "description": "If a theme is listed here it will stay active one more time before it will be changed",
+          "description": "Some themes, after they are applied, reload the instance. If they are present in this list the extension will not set a new random theme after they are applied.",
           "default": [
             "Material Theme",
             "Material Theme High Contrast",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
         "randomThemeSwitcher.lastSwitchDay": {
           "title": "last switch day",
           "type": "number",
-          "description": "Last switch day (used in the switchMode daily)"
+          "description": "Last switch day (used in the switchMode daily)",
+          "scope": "application"
         },
         "randomThemeSwitcher.oneMoreTimeThemeList": {
           "title": "one more time theme list",

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -24,7 +24,7 @@ export class CommandsIds {
 export class SettingsKeys {
     public static SwitchMode = 'switchMode';
     public static SwitchInterval = 'switchInterval';
-    public static OneMoreTimeThemeList = 'oneMoreTimeThemeList';
+    public static PreventReloadThemeList = 'preventReloadThemeList';
 }
 
 export class Messages {

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,5 +1,5 @@
 export const EXTENSION_NAME = 'randomThemeSwitcher';
-export const LAST_THEME_MATERIAL = 'last-theme-is-material';
+export const LAST_THEME_NEEDS_TO_PERSIST = 'last-theme-needs-to-persist';
 export const LAST_SWITCH_DAY = 'lastSwitchDay';
 export const MATERIAL_LIST = [
     'Material Theme',
@@ -24,6 +24,7 @@ export class CommandsIds {
 export class SettingsKeys {
     public static SwitchMode = 'switchMode';
     public static SwitchInterval = 'switchInterval';
+    public static OneMoreTimeThemeList = 'oneMoreTimeThemeList';
 }
 
 export class Messages {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { fromNullable, Option } from 'fp-ts/lib/Option';
 import { getRandomInt } from './utils';
-import { EXTENSION_NAME, MATERIAL_LIST, LAST_THEME_MATERIAL, Messages, CommandsIds, SettingsKeys, LAST_SWITCH_DAY, ThemeTypes } from './enums';
+import { EXTENSION_NAME, LAST_THEME_NEEDS_TO_PERSIST, Messages, CommandsIds, SettingsKeys, LAST_SWITCH_DAY, ThemeTypes, MATERIAL_LIST } from './enums';
 
 
 function getUserSettings(): vscode.WorkspaceConfiguration {
@@ -20,9 +20,10 @@ async function changeTheme(
   const userSettings = getUserSettings();
   const i = getRandomInt(themeList.length - 1);
   const newTheme = themeList[i];
+  const oneMoreTimeThemeList: string[] = <string[]>userSettings.get(SettingsKeys.OneMoreTimeThemeList, MATERIAL_LIST);
 
-  if (MATERIAL_LIST.findIndex(mat => mat === newTheme) && context !== undefined) {
-    await context.globalState.update(LAST_THEME_MATERIAL, true);
+  if (oneMoreTimeThemeList.findIndex(mat => mat === newTheme) && context !== undefined) {
+    await context.globalState.update(LAST_THEME_NEEDS_TO_PERSIST, true);
   }
 
   userSettings.update('workbench.colorTheme', newTheme, true).then(() => {
@@ -162,13 +163,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (e.affectsConfiguration('workbench.colorTheme')) {
         const userSettings = getUserSettings();
         const currentTheme = userSettings.get('workbench.colorTheme', '');
-        context.globalState.update(LAST_THEME_MATERIAL, MATERIAL_LIST.findIndex(mat => mat === currentTheme) !== -1);
+        const oneMoreTimeThemeList: string[] = <string[]>userSettings.get(SettingsKeys.OneMoreTimeThemeList, MATERIAL_LIST);
+
+        context.globalState.update(LAST_THEME_NEEDS_TO_PERSIST, oneMoreTimeThemeList.findIndex(mat => mat === currentTheme) !== -1);
         themeList = await getThemeList(getExtensionConfig(), getUserSettings());
       }
     })
   );
 
-  const isLastThemeMaterial = context.globalState.get(LAST_THEME_MATERIAL, false);
+  const isLastThemeMaterial = context.globalState.get(LAST_THEME_NEEDS_TO_PERSIST, false);
   themeList = await getThemeList(extensionConfig, getUserSettings());
   switchMode = extensionConfig.get(SettingsKeys.SwitchMode, 'manual');
 
@@ -197,7 +200,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       });
     }
   } else if (isLastThemeMaterial) {
-    context.globalState.update(LAST_THEME_MATERIAL, false);
+    context.globalState.update(LAST_THEME_NEEDS_TO_PERSIST, false);
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,9 +20,9 @@ async function changeTheme(
   const userSettings = getUserSettings();
   const i = getRandomInt(themeList.length - 1);
   const newTheme = themeList[i];
-  const oneMoreTimeThemeList: string[] = <string[]>userSettings.get(SettingsKeys.OneMoreTimeThemeList, MATERIAL_LIST);
+  const preventReloadThemeList: string[] = <string[]>userSettings.get(SettingsKeys.PreventReloadThemeList, MATERIAL_LIST);
 
-  if (oneMoreTimeThemeList.findIndex(mat => mat === newTheme) && context !== undefined) {
+  if (preventReloadThemeList.findIndex(mat => mat === newTheme) && context !== undefined) {
     await context.globalState.update(LAST_THEME_NEEDS_TO_PERSIST, true);
   }
 
@@ -163,7 +163,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (e.affectsConfiguration('workbench.colorTheme')) {
         const userSettings = getUserSettings();
         const currentTheme = userSettings.get('workbench.colorTheme', '');
-        const oneMoreTimeThemeList: string[] = <string[]>userSettings.get(SettingsKeys.OneMoreTimeThemeList, MATERIAL_LIST);
+        const oneMoreTimeThemeList: string[] = <string[]>userSettings.get(SettingsKeys.PreventReloadThemeList, MATERIAL_LIST);
 
         context.globalState.update(LAST_THEME_NEEDS_TO_PERSIST, oneMoreTimeThemeList.findIndex(mat => mat === currentTheme) !== -1);
         themeList = await getThemeList(getExtensionConfig(), getUserSettings());


### PR DESCRIPTION
Ciao,

Ho trasformato la MATERIAL_LIST nell' impostazione `oneMoreTimeThemeList`.

Facendo cosí chiunque puó impostare i propri temi preferiti,

Inoltre potrai rispondere all'issue #10 con:
prova ad impostare nei settings:
``` JSON
"oneMoreTimeThemeList": [ ]
```
e vedrai che cambierá in modo molto piú puntuale.